### PR TITLE
Replace calls to deprecated predicates

### DIFF
--- a/library/triplestore.pl
+++ b/library/triplestore.pl
@@ -520,7 +520,7 @@ triples_canonical([(D,G,A,B,C)|Triples],[(D,G,X,Y,Z)|Canonical]) :-
  */ 
 canonicalise_subject(O,C) :-
     (   string(O)
-    ->  string_to_atom(O,C)
+    ->  atom_string(C,O)
     ;   O=C).
 
 /* 

--- a/library/validate_instance.pl
+++ b/library/validate_instance.pl
@@ -599,7 +599,7 @@ refute_basetype_elt(literal(type(_,S)),'http://terminusdb.com/schema/xdd#json', 
                  }
     ).
 refute_basetype_elt(literal(type(_,S)),'http://www.w3.org/2001/XMLSchema#boolean',Reason) :-
-    (   \+ (string_to_atom(S,A), member(A,['true','false','1','0']))
+    (   \+ (atom_string(A,S), member(A,['true','false','1','0']))
     ->  Reason = _{
                      '@type' : 'vio:ViolationWithDatatypeObject',
                      'vio:message' : 'Not a well formed boolean.',

--- a/library/woql_compile.pl
+++ b/library/woql_compile.pl
@@ -365,7 +365,7 @@ compile_query(Term, Prog, Ctx_In, Ctx_Out) :-
 
 assert_program([]).
 assert_program([Def|Remainder]) :-
-    assert(Def),
+    assertz(Def),
     assert_program(Remainder).
 
 retract_program([]).


### PR DESCRIPTION
Minor cleanup of three calls to deprecated predicates detected by running the Logtalk linter.