### PR TITLE
Add missing multifile/1 directives

### DIFF
--- a/library/api.pl
+++ b/library/api.pl
@@ -83,6 +83,8 @@
 
 %% Set base location
 % We may want to allow this as a setting...
+:- multifile http:location/3.
+:- dynamic http:location/3.
 http:location(root, '/', []).
 
 :- http_handler(root(.), cors_catch(connect_handler(Method)),

--- a/library/frame.pl
+++ b/library/frame.pl
@@ -265,6 +265,7 @@ is_class_formula(restriction(Restriction)) :-
 is_class_formula(class(Class)) :-
     is_uri(Class).
 
+:- multifile error:has_type/2.
 error:has_type(class_formula,X) :-
     is_class_formula(X).
 

--- a/library/frame_types.pl
+++ b/library/frame_types.pl
@@ -64,6 +64,8 @@ is_property_restriction(L) :-
 is_property_restriction(L) :-
     member(someValuesFrom=_,L).
 
+:- multifile error:has_type/2.
+
 error:has_type(property_restriction,X) :-
     is_property_restriction(X).
 

--- a/library/journaling.pl
+++ b/library/journaling.pl
@@ -123,6 +123,9 @@ write_triple(C,G,Type,PX,PY,PZ) :-
  * Goal expansion for write_triple in order to 
  * make static code references to ontologies less painful.
  */
+:- multifile user:goal_expansion/2.
+:- dynamic user:goal_expansion/2.
+
 user:goal_expansion(write_triple(DB,G,T,A,Y,Z),write_triple(DB,G,T,X,Y,Z)) :-
     nonvar(A),
     global_prefix_expand(A,X).

--- a/library/types.pl
+++ b/library/types.pl
@@ -60,6 +60,7 @@ is_literal(literal(type(Type,_Data))) :-
     % this should probably have the full xsd build out.
     atom(Type).
 
+:- multifile error:has_type/2.
 error:has_type(literal,X) :-
     is_literal(X).
 

--- a/library/upgrade_db.pl
+++ b/library/upgrade_db.pl
@@ -136,6 +136,9 @@ run_upgrade([Version1,Version2|Rest]) :-
  * head terms from run_upgrade_step/2 so we can check accessibility
  * of an upgrade.
  */
+:- multifile user:term_expansion/2.
+:- dynamic user:term_expansion/2.
+
 user:term_expansion((run_upgrade_step(X,Y):-Body),
                     [(run_upgrade_step(X,Y):-Body),
                      upgrade_step(X,Y)]).


### PR DESCRIPTION
SWI-Prolog is actually quite permissive regarding missing `multifile/1` directives. But it's still good programming style to include them whenever defining clauses for multifile predicates.