### PR TITLE
Replace calls to deprecated predicate string_to_atom/2

### DIFF
--- a/library/database.pl
+++ b/library/database.pl
@@ -174,7 +174,7 @@ database_name_list(Database_Atoms) :-
                      DB_Resource, terminus:id, literal(type(_,Database_Name)))),
             Database_Names),
 
-    maplist(string_to_atom, Database_Names, Database_Atomised),
+    maplist(atom_string, Database_Atomised, Database_Names),
     exclude(terminus_database_name, Database_Atomised, Database_Atoms).
 
 database_record_list(Databases) :-

--- a/library/json_woql.pl
+++ b/library/json_woql.pl
@@ -208,7 +208,7 @@ json_to_woql_ast(JSON,WOQL) :-
         WOQL = not(WQ)
     ;   _{'http://terminusdb.com/woql#as' : [ S, V ] } :< JSON
     ->  (   _{'@value' : WS} :< S
-        ->  string_to_atom(WS,WA),
+        ->  atom_string(WA,WS),
             json_to_woql_ast(V,WV),
             WOQL = as(WA,WV)
         ;   throw(http_reply(not_found(_{'@type' : 'vio:WOQLSyntaxError',
@@ -222,11 +222,11 @@ json_to_woql_ast(JSON,WOQL) :-
     ->  WOQL = '@'(V,L)
     ;   _{'http://terminusdb.com/woql#value' : V, '@type' : T } :< JSON
     ->  json_to_woql_ast(V,VE),
-        string_to_atom(T,TE),
+        atom_string(TE,T),
         WOQL = '^^'(VE,TE)
     ;   _{'http://terminusdb.com/woql#value' : V, '@lang' : L } :< JSON
     ->  json_to_woql_ast(V,VE),
-        string_to_atom(L,LE),
+        atom_string(LE,L),
         WOQL = '@'(VE,LE)
     ;   _{'@id' : ID } :< JSON
     ->  json_to_woql_ast(ID,WOQL)

--- a/library/jsonld.pl
+++ b/library/jsonld.pl
@@ -234,7 +234,7 @@ expand_key(K,Context,Key,Value) :-
     ->  (   is_dict(R)
         ->  Key = Key_Candidate,
             Value = R
-        ;   string_to_atom(R,Key),
+        ;   atom_string(Key,R),
             Value = _{})
     ;   Key = Key_Candidate,
         Value = _{}).

--- a/library/literals.pl
+++ b/library/literals.pl
@@ -147,4 +147,4 @@ storage_object(node(S),O) :-
     ->  (   atom(O)
         ->  atom_string(O,S)
         ;   O = S)
-    ;   string_to_atom(S,O)).
+    ;   atom_string(O,S)).


### PR DESCRIPTION
Replace calls to deprecated predicate `string_to_atom/2` predicate with calls to  the built-in predicate `atom_string/2`. Found by the Logtalk linter 😛