### PR TITLE
Avoid creating unused atoms by using sub_atom/5 instead of atom_concat/3

### DIFF
--- a/library/file_utils.pl
+++ b/library/file_utils.pl
@@ -146,7 +146,7 @@ subdirectories(Dir,Dirs) :-
  */
 excluded_file(File) :-
     % emacs files
-    atom_concat('.#', _, File).
+    sub_atom(File, 0, _, _, '.#').
 excluded_file(File) :-
     % current directory and parent directory
     member(File, ['.','..']).

--- a/library/json_woql.pl
+++ b/library/json_woql.pl
@@ -252,7 +252,7 @@ json_to_woql_ast(JSON,_) :-
                                  'terminus:status' : 'terminus:failure'}))).
 
 is_json_var(A) :-
-    atom_concat('http://terminusdb.com/woql/variable/',_,A).
+    sub_atom(A, 0, _, _, 'http://terminusdb.com/woql/variable/').
 
 json_to_woql_arith(JSON,WOQL) :-
     is_dict(JSON),


### PR DESCRIPTION
Unused atoms just add to the atom garbage collector burden.