### PR TITLE
WIP: Fix use module directives

### DIFF
--- a/library/api.pl
+++ b/library/api.pl
@@ -47,37 +47,37 @@
 :- use_module(library(http/http_authenticate)).
 
 % Load capabilities library
-:- use_module(library(capabilities)).
+:- use_module(capabilities).
 
 % woql libraries
-:- use_module(library(woql_compile)).
+:- use_module(woql_compile).
 
 % Default utils
-:- use_module(library(utils)).
+:- use_module(utils).
 
 % Database utils
-:- use_module(library(database_utils)).
+:- use_module(database_utils).
 
 % Database construction utils
-:- use_module(library(database)).
+:- use_module(database).
 
 % Frame and document processing
-:- use_module(library(frame)).
+:- use_module(frame).
 
 % JSON manipulation
-:- use_module(library(jsonld)).
+:- use_module(jsonld).
 
 % JSON Queries
-:- use_module(library(json_woql)).
+:- use_module(json_woql).
 
 % File processing
-:- use_module(library(file_utils), [terminus_path/1]).
+:- use_module(file_utils, [terminus_path/1]).
 
 % Validation
-:- use_module(library(validate)).
+:- use_module(validate).
 
 % Dumping turtle
-:- use_module(library(turtle_utils)).
+:- use_module(turtle_utils).
 
 %%%%%%%%%%%%% API Paths %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/library/capabilities.pl
+++ b/library/capabilities.pl
@@ -38,14 +38,14 @@
 
 :- use_module(config(config),[]).
 :- use_module(library(crypto)).
-:- use_module(library(utils)).
-:- use_module(library(file_utils)).
-:- use_module(library(triplestore)).
-:- use_module(library(frame)).
-:- use_module(library(jsonld)).
-:- use_module(library(database)).
-:- use_module(library(database_utils)).
-:- use_module(library(sdk)).
+:- use_module(utils).
+:- use_module(file_utils).
+:- use_module(triplestore).
+:- use_module(frame).
+:- use_module(jsonld).
+:- use_module(database).
+:- use_module(database_utils).
+:- use_module(sdk).
 :- op(1050, xfx, =>).
 
 /**

--- a/library/casting.pl
+++ b/library/casting.pl
@@ -26,9 +26,9 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(utils)).
-:- use_module(library(prefixes)).
-:- use_module(library(speculative_parse)).
+:- use_module(utils).
+:- use_module(prefixes).
+:- use_module(speculative_parse).
 
 :- use_module(library(apply)).
 :- use_module(library(yall)).

--- a/library/database_utils.pl
+++ b/library/database_utils.pl
@@ -31,11 +31,11 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(file_utils)).
-:- use_module(library(triplestore)).
-:- use_module(library(utils)).
-:- use_module(library(database)).
-:- use_module(library(expansions)).
+:- use_module(file_utils).
+:- use_module(triplestore).
+:- use_module(utils).
+:- use_module(database).
+:- use_module(expansions).
 
 /*
  * database_exists(DB_URI) is semidet.

--- a/library/expansions.pl
+++ b/library/expansions.pl
@@ -23,7 +23,7 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(global_prefixes)).
+:- use_module(global_prefixes).
 
 % xrdf/5
 user:goal_expansion(xrdf(DB,G,A,Y,Z),xrdf(DB,G,X,Y,Z)) :-

--- a/library/frame.pl
+++ b/library/frame.pl
@@ -54,19 +54,19 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(utils)).
-:- use_module(library(base_type)).
-:- use_module(library(triplestore)).
-:- use_module(library(validate_schema), except([document/2])).
-:- use_module(library(validate_instance)).
-:- use_module(library(inference)).
-:- use_module(library(database)).
-:- use_module(library(schema), []).
-:- use_module(library(types)).
-:- use_module(library(frame_types)).
-:- use_module(library(jsonld)).
-:- use_module(library(prefixes)).
-:- use_module(library(expansions)).
+:- use_module(utils).
+:- use_module(base_type).
+:- use_module(triplestore).
+:- use_module(validate_schema, except([document/2])).
+:- use_module(validate_instance).
+:- use_module(inference).
+:- use_module(database).
+:- use_module(schema, []).
+:- use_module(types).
+:- use_module(frame_types).
+:- use_module(jsonld).
+:- use_module(prefixes).
+:- use_module(expansions).
 
 :- use_module(library(apply)).
 :- use_module(library(yall)).

--- a/library/inference.pl
+++ b/library/inference.pl
@@ -25,10 +25,10 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(database)).
-:- use_module(library(validate_schema)).
-:- use_module(library(triplestore)).
-:- use_module(library(expansions)).
+:- use_module(database).
+:- use_module(validate_schema).
+:- use_module(triplestore).
+:- use_module(expansions).
 
 /**
  * runChain(?X,?P:list(uri),?Y,+Instance:atom,+Database:database is nondet.

--- a/library/json_woql.pl
+++ b/library/json_woql.pl
@@ -27,8 +27,8 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(utils)).
-:- use_module(library(jsonld)).
+:- use_module(utils).
+:- use_module(jsonld).
 
 :- use_module(library(apply)).
 :- use_module(library(yall)).

--- a/library/jsonld.pl
+++ b/library/jsonld.pl
@@ -36,11 +36,11 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 :- use_module(library(pairs)).
-:- use_module(library(utils)).
 :- use_module(library(http/json)).
 % Currently a bug in groundedness checking.
 %:- use_module(library(mavis)).
-:- use_module(library(database)).
+:- use_module(utils).
+:- use_module(database).
 
 % efficiency
 :- use_module(library(apply)).

--- a/library/jsonld.pl
+++ b/library/jsonld.pl
@@ -36,10 +36,10 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 :- use_module(library(pairs)).
+:- use_module(utils).
 :- use_module(library(http/json)).
 % Currently a bug in groundedness checking.
 %:- use_module(library(mavis)).
-:- use_module(utils).
 :- use_module(database).
 
 % efficiency

--- a/library/prefixes.pl
+++ b/library/prefixes.pl
@@ -38,8 +38,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 % Import global definitions
-:- use_module(library(global_prefixes)).
-:- reexport(library(global_prefixes)).
+:- use_module(global_prefixes).
+:- reexport(global_prefixes).
 
 % Use prolog persistency for prefix management.
 % We could use the DB itself but this gets a bit too metacircular!
@@ -48,15 +48,15 @@
 % Set up the database style
 :- persistent prefix(collection:atom,prefix:atom,uri:atom).
 
-:- use_module(library(file_utils)).
-:- use_module(library(utils)).
+:- use_module(file_utils).
+:- use_module(utils).
 
 % JSON manipulation
 :- use_module(library(http/json)).
 
-:- use_module(library(jsonld)).
+:- use_module(jsonld).
 
-:- use_module(library(database), [
+:- use_module(database, [
                   database_name_list/1,
                   terminus_database_name/1
               ]).

--- a/library/relationships.pl
+++ b/library/relationships.pl
@@ -28,10 +28,10 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(utils)).
-:- use_module(library(validate_schema)).
-:- use_module(library(database)).
-:- use_module(library(triplestore)).
+:- use_module(utils).
+:- use_module(validate_schema).
+:- use_module(database).
+:- use_module(triplestore).
 :- use_module(library(semweb/rdf_db)).
 
 relationship_source_property(Relationship,Property,Database) :-

--- a/library/schema.pl
+++ b/library/schema.pl
@@ -28,12 +28,12 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(prefixes), [global_prefix_expand/2]).
-:- use_module(library(database)).
-:- use_module(library(triplestore)).
-:- use_module(library(schema_definitions)).
-:- use_module(library(schema_util)).
-:- use_module(library(utils)).
+:- use_module(prefixes, [global_prefix_expand/2]).
+:- use_module(database).
+:- use_module(triplestore).
+:- use_module(schema_definitions).
+:- use_module(schema_util).
+:- use_module(utils).
 
 :- reexport(schema_util).
 

--- a/library/schema_util.pl
+++ b/library/schema_util.pl
@@ -31,10 +31,10 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 
-:- use_module(library(utils), [intersperse/3]).
-:- use_module(library(database)).
-:- use_module(library(types)).
-:- use_module(library(schema_definitions)).
+:- use_module(utils, [intersperse/3]).
+:- use_module(database).
+:- use_module(types).
+:- use_module(schema_definitions).
 
 /*
  * database_module(+Database:database, -Module:atom) is det.

--- a/library/sdk.pl
+++ b/library/sdk.pl
@@ -27,10 +27,10 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(utils)).
-:- use_module(library(database)).
-:- use_module(library(woql_compile)).
-:- use_module(library(woql_term)).
+:- use_module(utils).
+:- use_module(database).
+:- use_module(woql_compile).
+:- use_module(woql_term).
 
 :- reexport(woql_term).
 

--- a/library/skolemise.pl
+++ b/library/skolemise.pl
@@ -30,7 +30,7 @@
 :- use_module(library(apply)).
 :- use_module(library(yall)).
 :- use_module(library(apply_macros)).
-:- use_module(library(triplestore)).
+:- use_module(triplestore).
 
 /*
  * blank_node(+URI) is det.

--- a/library/triplestore.pl
+++ b/library/triplestore.pl
@@ -12,19 +12,19 @@
               storage/1
           ]).
 
-:- use_module(library(terminus_store)).
-:- reexport(library(terminus_store),
+:- use_module(terminus_store).
+:- reexport(terminus_store,
             except([create_named_graph/3,
                     open_named_graph/3])).
 
-:- use_module(library(file_utils)).
-:- use_module(library(utils)).
-:- use_module(library(schema), [cleanup_schema_module/1]).
-:- use_module(library(prefixes)).
-:- use_module(library(types)).
+:- use_module(file_utils).
+:- use_module(utils).
+:- use_module(schema, [cleanup_schema_module/1]).
+:- use_module(prefixes).
+:- use_module(types).
 % feeling very circular :(
-:- use_module(library(database)).
-:- use_module(library(literals)).
+:- use_module(database).
+:- use_module(literals).
 
 :- use_module(library(apply)).
 :- use_module(library(yall)).

--- a/library/triplestore.pl
+++ b/library/triplestore.pl
@@ -12,8 +12,8 @@
               storage/1
           ]).
 
-:- use_module(terminus_store).
-:- reexport(terminus_store,
+:- use_module(library(terminus_store)).
+:- reexport(library(terminus_store),
             except([create_named_graph/3,
                     open_named_graph/3])).
 

--- a/library/turtle_utils.pl
+++ b/library/turtle_utils.pl
@@ -25,8 +25,8 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(prefixes)).
-:- use_module(library(triplestore)).
+:- use_module(prefixes).
+:- use_module(triplestore).
 :- use_module(library(semweb/turtle)).
 
 /**

--- a/library/validate.pl
+++ b/library/validate.pl
@@ -26,20 +26,20 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(triplestore)).
-:- use_module(library(database)).
-:- use_module(library(utils)).
-:- use_module(library(schema),[
+:- use_module(triplestore).
+:- use_module(database).
+:- use_module(utils).
+:- use_module(schema,[
                   database_module/2,
                   compile_schema_to_module/2
               ]).
-:- use_module(library(validate_schema)).
-:- use_module(library(validate_instance)).
-:- use_module(library(frame)).
-:- use_module(library(jsonld)).
+:- use_module(validate_schema).
+:- use_module(validate_instance).
+:- use_module(frame).
+:- use_module(jsonld).
 :- use_module(library(semweb/turtle)).
 
-:- use_module(library(literals)).
+:- use_module(literals).
 
 % For debugging
 :- use_module(library(http/http_log)).

--- a/library/validate_instance.pl
+++ b/library/validate_instance.pl
@@ -29,14 +29,14 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(validate_schema)).
-:- use_module(library(database)).
-:- use_module(library(triplestore)).
-:- use_module(library(utils)).
-:- use_module(library(types)).
-:- use_module(library(base_type)).
-:- use_module(library(inference)).
-:- use_module(library(expansions)).
+:- use_module(validate_schema).
+:- use_module(database).
+:- use_module(triplestore).
+:- use_module(utils).
+:- use_module(types).
+:- use_module(base_type).
+:- use_module(inference).
+:- use_module(expansions).
 :- use_module(library(http/json)).
 
 /**

--- a/library/validate_schema.pl
+++ b/library/validate_schema.pl
@@ -98,12 +98,12 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(database)).
-:- use_module(library(triplestore)).
-:- use_module(library(utils)).
-:- use_module(library(types)).
-:- use_module(library(base_type)).
-:- use_module(library(validate_instance)).
+:- use_module(database).
+:- use_module(triplestore).
+:- use_module(utils).
+:- use_module(types).
+:- use_module(base_type).
+:- use_module(validate_instance).
 
 /*
  * Vio JSON util

--- a/library/woql_compile.pl
+++ b/library/woql_compile.pl
@@ -31,28 +31,28 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(database)).
-:- use_module(library(woql_term)).
-:- use_module(library(utils), except([elt/2])).
-:- use_module(library(triplestore), [
+:- use_module(database).
+:- use_module(woql_term).
+:- use_module(utils, except([elt/2])).
+:- use_module(triplestore, [
                   xrdf/5,
                   insert/5,
                   delete/5
               ]).
-%:- use_module(library(schema)).
-:- use_module(library(relationships), [
+%:- use_module(schema).
+:- use_module(relationships, [
                   relationship_source_property/3,
                   relationship_target_property/3
               ]).
-:- use_module(library(inference)).
+:- use_module(inference).
 :- use_module(library(http/json)).
 :- use_module(library(http/json_convert)).
 :- use_module(library(solution_sequences)).
 
-:- use_module(library(jsonld)).
-:- use_module(library(json_woql)).
+:- use_module(jsonld).
+:- use_module(json_woql).
 
-:- use_module(library(frame), [
+:- use_module(frame, [
                   update_object/3,
                   delete_object/2
               ]).
@@ -60,13 +60,13 @@
 % We may need to patch this in again...
 %:- use_module(query, [enrich_graph_fragment/5]).
 
-:- use_module(library(validate_schema), [datatypeProperty/2, objectProperty/2]).
-:- use_module(library(casting), [typecast/4,hash/3]).
+:- use_module(validate_schema, [datatypeProperty/2, objectProperty/2]).
+:- use_module(casting, [typecast/4,hash/3]).
 
 % This should really not be used... it is too low level - Gavin
 %:- use_module(journaling, [write_triple/5]).
 
-:- use_module(library(remote_file), [
+:- use_module(remote_file, [
                   copy_remote/4
               ]).
 


### PR DESCRIPTION
This pull request changes `use_module/1-2` directives to use just the name of the module files for local modules instead of using a `library(File)` argument. The main motivation for these changes is to avoid relying on the file search mechanism for the overloaded `library` alias for local modules and thus (1) improve loading times and (2) avoid the unlikely but still possible bug of loading a third-party and thus the wrong module due to an order issue during `library(File)` search. A possible alternative is to define and use an alias other than `library`. E.g. `terminus_core`.

I marked this pull request as WIP due to the scope of the changes and also due to the pending merging of the automatic test workflow as I'm currently unable to test the changes locally on my macOS laptop. 