### PR TITLE
Remove redundant module explicit qualification from cors_catch/2 definition

### DIFF
--- a/library/api.pl
+++ b/library/api.pl
@@ -122,8 +122,8 @@ http:location(root, '/', []).
 
 % Evil mechanism for catching, putting CORS headers and re-throwing.
 :- meta_predicate cors_catch(1,?).
-cors_catch(M:Goal,Request) :-
-    catch(call(M:Goal, Request),
+cors_catch(Goal,Request) :-
+    catch(call(Goal, Request),
           E,
           (   cors_enable,
               http_log_stream(Log),


### PR DESCRIPTION
As `cors_catch/2` is declared as a meta-predicate, the meta-argument is implicitly qualified by the runtime. Moreover, the predicate clause doesn't make use of the module qualifier.