### PR TITLE
Fix database module use_module/1 directives for local modules

### DIFF
--- a/library/database.pl
+++ b/library/database.pl
@@ -54,16 +54,15 @@
  *                                                                       *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-:- use_module(library(utils)).
-:- use_module(library(types)).
-:- use_module(library(sdk)).
-:- use_module(library(file_utils)).
+:- use_module(utils).
+:- use_module(types).
+:- use_module(sdk).
+:- use_module(file_utils).
+:- use_module(triplestore).
+
 :- use_module(library(prolog_stack)).
-
-
 :- use_module(library(apply)).
 :- use_module(library(apply_macros)).
-:- use_module(library(triplestore)).
 
 /*
  * Database term accessors.


### PR DESCRIPTION
This pull request changes `use_module/1` directives in the `database` module to use just the name of the module files for local modules instead of using a `library(File)` argument. The main motivation for these changes is to avoid relying on the file search mechanism for the overloaded library alias for local modules and thus (1) improve loading times and (2) avoid the unlikely but still possible bug of loading a third-party and thus the wrong module due to an order issue during `library(File)` search.