### PR TITLE
Delete use_module/1 directives subsumed by reexport/1 directives

### DIFF
--- a/library/prefixes.pl
+++ b/library/prefixes.pl
@@ -38,7 +38,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 % Import global definitions
-:- use_module(global_prefixes).
 :- reexport(global_prefixes).
 
 % Use prolog persistency for prefix management.

--- a/library/schema.pl
+++ b/library/schema.pl
@@ -32,7 +32,6 @@
 :- use_module(database).
 :- use_module(triplestore).
 :- use_module(schema_definitions).
-:- use_module(schema_util).
 :- use_module(utils).
 
 :- reexport(schema_util).

--- a/library/sdk.pl
+++ b/library/sdk.pl
@@ -30,7 +30,6 @@
 :- use_module(utils).
 :- use_module(database).
 :- use_module(woql_compile).
-:- use_module(woql_term).
 
 :- reexport(woql_term).
 

--- a/library/triplestore.pl
+++ b/library/triplestore.pl
@@ -11,7 +11,6 @@
               storage/1
           ]).
 
-:- use_module(library(terminus_store)).
 :- reexport(library(terminus_store),
             except([create_named_graph/3,
                     open_named_graph/3])).
@@ -117,7 +116,7 @@ sync_backing_store :-
  */
 safe_create_named_graph(Store,Graph_ID,Graph_Obj) :-
     www_form_encode(Graph_ID,Safe_Graph_ID),
-    create_named_graph(Store,Safe_Graph_ID,Graph_Obj).
+    terminus_store:create_named_graph(Store,Safe_Graph_ID,Graph_Obj).
 
 /*
  * safe_open_named_graph(+Store,+Graph_ID,-Graph_Obj) is det.
@@ -126,7 +125,7 @@ safe_create_named_graph(Store,Graph_ID,Graph_Obj) :-
  */
 safe_open_named_graph(Store, Graph_ID, Graph_Obj) :-
     www_form_encode(Graph_ID,Safe_Graph_ID),
-    open_named_graph(Store,Safe_Graph_ID,Graph_Obj).
+    terminus_store:open_named_graph(Store,Safe_Graph_ID,Graph_Obj).
 
 
 /**


### PR DESCRIPTION
The `reexport/1` directive subsumes the `use_module/1` directive. The latter is not necessary when the former is used. Same for the arity two variants.