### PR TITLE
Add missing operator directives to the capabilities and database modules

### DIFF
--- a/library/capabilities.pl
+++ b/library/capabilities.pl
@@ -46,6 +46,8 @@
 :- use_module(database).
 :- use_module(database_utils).
 :- use_module(sdk).
+
+:- op(2, xfx, ^^).
 :- op(1050, xfx, =>).
 
 /**

--- a/library/database.pl
+++ b/library/database.pl
@@ -67,6 +67,8 @@
 :- use_module(library(apply)).
 :- use_module(library(apply_macros)).
 
+:- op(2, xfx, ^^).
+
 /*
  * Database term accessors.
  *


### PR DESCRIPTION
These two modules don't import the modules defining those operators