### PR TITLE
Add missing import to module jsonld

### DIFF
--- a/library/jsonld.pl
+++ b/library/jsonld.pl
@@ -41,6 +41,7 @@
 % Currently a bug in groundedness checking.
 %:- use_module(library(mavis)).
 :- use_module(database).
+:- use_module(prefixes).
 
 % efficiency
 :- use_module(library(apply)).


### PR DESCRIPTION
The `jsonld` module calls the `get_global_jsonld_context/1` predicate exported by the `prefixes` module.