### PR TITLE
Add missing import of module prefixes to module sdk

### DIFF
--- a/library/sdk.pl
+++ b/library/sdk.pl
@@ -30,6 +30,7 @@
 :- use_module(utils).
 :- use_module(database).
 :- use_module(woql_compile).
+:- use_module(prefixes).
 
 :- reexport(woql_term).
 


### PR DESCRIPTION
The`sdk` module calls the `get_collection_prefix_list/2` predicate exported by the `prefixes` module.