### PR TITLE
Missing import in validate_schema module

### DIFF
--- a/library/validate_schema.pl
+++ b/library/validate_schema.pl
@@ -103,6 +103,7 @@
 :- use_module(types).
 :- use_module(base_type).
 :- use_module(validate_instance).
+:- use_module(database_utils).
 
 /*
  * Vio JSON util


### PR DESCRIPTION
The `validate_schema` module calls the `database_utils:database_schema/2` predicate but the corresponding `use_module(database_utils)` directive is missing.