### PR TITLE
Add missing imports to resolve called predicates

### DIFF
--- a/core/query/frame.pl
+++ b/core/query/frame.pl
@@ -57,6 +57,7 @@
 :- use_module(ask).
 :- use_module(frame_types).
 :- use_module(jsonld).
+:- use_module(global_prefixes).
 
 :- use_module(core(util)).
 :- use_module(core(triple)).

--- a/core/triple/database_utils.pl
+++ b/core/triple/database_utils.pl
@@ -46,6 +46,8 @@
 
 :- use_module(core(transaction/database)).
 
+:- use_module(core(util/utils)).
+
 :- use_module(library(pcre)).
 
 /*


### PR DESCRIPTION
The `global_prefix_expand2` predicate is called from `frame.pl` and the `merge_separator_split/3` is called from `database_utils.pl`.